### PR TITLE
prevent from hangning in cv2.imshow()/cv2.waitkey

### DIFF
--- a/mmcv/visualization/image.py
+++ b/mmcv/visualization/image.py
@@ -14,7 +14,15 @@ def imshow(img, win_name='', wait_time=0):
         wait_time (int): Value of waitKey param.
     """
     cv2.imshow(win_name, imread(img))
-    cv2.waitKey(wait_time)
+    if wait_time == 0: # prevent from hangning if windows was closed
+        while True:
+            ret = cv2.waitKey(1)
+
+            closed = cv2.getWindowProperty(win_name, cv2.WND_PROP_VISIBLE) < 1
+            if closed or ret != -1: # if user closed window or if some key pressed
+                break
+    else:
+        ret = cv2.waitKey(wait_time)
 
 
 def imshow_bboxes(img,


### PR DESCRIPTION
case:
Window has been closed after cv2.imshow; cv2.waitKey;
expected behavior:
- continue program
actual  behavior:
- program hangs

This commit fixes it